### PR TITLE
chore(deps): pin github actions to immutable commit sha

### DIFF
--- a/.github/workflows/govulncheck-github-issues.yml
+++ b/.github/workflows/govulncheck-github-issues.yml
@@ -13,7 +13,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Checkout Configuration
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Load Repository List
         id: set-matrix
@@ -38,7 +38,7 @@ jobs:
         repo: ${{ fromJson(needs.load-targets.outputs.matrix) }}
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: 'stable'
 
@@ -168,7 +168,7 @@ jobs:
           jq -s --arg repo "$TARGET_REPO" --arg branch "$TARGET_BRANCH" '{repo: $repo, branch: $branch, findings: .}' findings.jsonl > "report-${REPO_SAFE_NAME}.json"
 
       - name: Upload Findings Artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: findings-${{ env.REPO_SAFE_NAME }}
           path: report-${{ env.REPO_SAFE_NAME }}.json
@@ -183,7 +183,7 @@ jobs:
       contents: read
     steps:
       - name: Download All Artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           pattern: findings-*
           path: all-findings


### PR DESCRIPTION
# Description:
This updates the workflow to pin all GitHub Actions `uses:` references to full commit SHAs instead of floating major tags.

# Pinned actions:
- `actions/checkout` -> `de0fac2e4500dabe0009e67214ff5f5447ce83dd` (`v6`)
- `actions/setup-go` -> `4a3601121dd01d1626a1e23e37211e3254c1c06c` (`v6`)
- `actions/upload-artifact` -> `bbbca2ddaa5d8feaa63e36b76fdaad77386f024f` (`v7`)
- `actions/download-artifact` -> `37930b1c2abaa49bbe596cd826c3c89aef350131` (`v7`)

# Verification:
To verify the pinned SHAs match the intended action tags, run:

```bash
git ls-remote https://github.com/actions/checkout refs/tags/v6
git ls-remote https://github.com/actions/setup-go refs/tags/v6
git ls-remote https://github.com/actions/upload-artifact refs/tags/v7
git ls-remote https://github.com/actions/download-artifact refs/tags/v7
```