### PR TITLE
chore: update release branches

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -5,11 +5,7 @@
   },
   {
     "name": "openbao/openbao",
-    "branch": "release/2.5.x"
-  },
-  {
-    "name": "openbao/openbao",
-    "branch": "release/2.4.x"
+    "branch": "release/2.6.x"
   },
   {
     "name": "openbao/openbao-k8s",


### PR DESCRIPTION
Remove v2.4.x and v2.5.x, add v2.6.x.

I'm willing to be convinced to keep v2.5.x even though it will likely see no further release. v2.4.x is very outdated at this point and entirely unsupported, so monitoring it just creates unnecessary noise.

@weberval thoughts? Did you envision this differently?

I can take care of cleaning up old issues (I'm not sure the workflow handles removing branches/repos yet) though it would be nice to figure that out at some point, too.