### PR TITLE
Don't scan archived repos

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -30,13 +30,5 @@
   {
     "name": "openbao/go-secure-stdlib",
     "branch": "main"
-  },
-  {
-    "name": "openbao/openbao-secrets-operator",
-    "branch": "main"
-  },
-  {
-    "name": "openbao/openbao-plugin-auth-jwt",
-    "branch": "main"
   }
 ]


### PR DESCRIPTION
Removing openbao-secrets-operator and openbao-plugin-auth-jwt to reduce noise as both are archived.